### PR TITLE
Update the install link button

### DIFF
--- a/src/links.json
+++ b/src/links.json
@@ -1,5 +1,5 @@
 {
-  "install": "http://install.dappnode.io/",
+  "install": "https://docs.dappnode.io/get-started/installation/custom-hardware/installation/overview",
   "shop": "http://shop.dappnode.io/",
   "docs": "http://docs.dappnode.io/",
   "riot": "https://riot.im/app/#/room/#DAppNode:matrix.org",


### PR DESCRIPTION
The current link http://install.dappnode.io is down. This PR update where the user is redirected to after pressing the button. If you press the button you are redirected to https://docs.dappnode.io/get-started/installation/custom-hardware/installation/overview